### PR TITLE
Avoid panic when keyboards use different layouts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use swayipc::{Connection, Input};
 
 #[derive(Debug)]
 enum Error {
-    InconsistentLayouts,
     NoKeyboards,
 }
 
@@ -21,16 +20,56 @@ pub extern "C" fn Xkb_Switch_getXkbLayout() -> *const c_char {
 }
 
 fn get_cur_layout(conn: &mut Connection) -> Result<String, Error> {
-    let mut layouts: Vec<String> = get_keyboards(conn)
-        .drain(..)
-        .filter_map(|kb| kb.xkb_active_layout_name)
-        .collect();
-    layouts.dedup();
-    match layouts.leak() {
-        [] => Err(Error::NoKeyboards),
-        [layout] => Ok(layout.to_string()),
-        _ => Err(Error::InconsistentLayouts),
+    let keyboards = get_keyboards(conn);
+
+    // Build counts as Vec<(layout_name, count)>
+    let mut counts: Vec<(String, usize)> = Vec::new();
+    for kb in &keyboards {
+        if let Some(name) = kb.xkb_active_layout_name.clone() {
+            if let Some((_, c)) = counts.iter_mut().find(|(n, _)| *n == name) {
+                *c += 1;
+            } else {
+                counts.push((name, 1));
+            }
+        }
     }
+    if counts.is_empty() {
+        return Err(Error::NoKeyboards);
+    }
+
+    // Aggregate rank of a layout across keyboards: (sum_of_indices, present_count)
+    let score = |layout: &str| -> (usize, usize) {
+        let mut sum = 0usize;
+        let mut present = 0usize;
+        for kb in &keyboards {
+            if let Some(i) = kb.xkb_layout_names.iter().position(|x| x == layout) {
+                sum += i;
+                present += 1;
+            }
+        }
+        (sum, present)
+    };
+
+    // Choose best by: count desc, score(sum asc), present desc, name lex asc
+    let mut best = counts[0].0.clone();
+    let mut best_n = counts[0].1;
+    let mut best_s = score(&best);
+
+    for (name, n) in counts.into_iter().skip(1) {
+        let s = score(&name);
+        let better =
+            n > best_n ||
+            (n == best_n && (s.0 < best_s.0 ||
+                             (s.0 == best_s.0 && (s.1 > best_s.1 ||
+                                                  (s.1 == best_s.1 && name < best)))));
+        if better {
+            best = name;
+            best_n = n;
+            best_s = s;
+        }
+    }
+
+    Ok(best)
 }
 
 fn get_keyboards(conn: &mut Connection) -> Vec<Input> {
@@ -53,11 +92,11 @@ pub extern "C" fn Xkb_Switch_setXkbLayout(layout_ptr: *const c_char) {
 
 fn switch_layout(conn: &mut Connection, layout: &String) {
     get_keyboards(conn).iter().for_each(|kb| {
-        let layout_index = kb
+        let Some(layout_index) = kb
             .xkb_layout_names
             .iter()
             .position(|x| x == layout)
-            .unwrap();
+        else { return; };
 
         let _ = conn.run_command(format!(
             "input {} xkb_switch_layout {}",


### PR DESCRIPTION
The previous implementation assumed that all keyboard devices always shared the same active XKB layout and returned an error when multiple layouts were observed.

On systems with multiple keyboards (e.g. internal and external), layouts are maintained per device, so layout disagreement is expected.

Replace the strict single-layout assumption with a deterministic master layout selection: count active layouts across keyboards, prefer the most common one, break ties using per-device layout order, and fall back to a stable lexicographic comparison.

This prevents InconsistentLayouts errors on systems with multiple keyboards and with mixed-layout setups.